### PR TITLE
HOTFIX Validating when we have an object value and avoid client side error

### DIFF
--- a/components/form/confirmation.tsx
+++ b/components/form/confirmation.tsx
@@ -79,6 +79,7 @@ export const Confirmation = ({ data, setOpen }: ConfirmationProps) => {
           <ScrollArea className="m-4">
             {Object.keys(data).map(
               (label, index) =>
+                typeof data[label] !== 'object' &&
                 !label.startsWith('cod_') &&
                 label !== VIOLENCIA_ASOCIADA &&
                 label !== URL_CORTO_NOTICIA && (


### PR DESCRIPTION
# Description

This issue was caused because we could have new columns with object values, like Data Objects, thats causes a client side error